### PR TITLE
Configure URLs from environment file

### DIFF
--- a/dtool-lookup-webapp/.eslintrc.js
+++ b/dtool-lookup-webapp/.eslintrc.js
@@ -5,7 +5,8 @@ module.exports = {
   },
   extends: ["plugin:vue/essential", "@vue/prettier"],
   rules: {
-    "no-console": process.env.NODE_ENV === "production" ? "error" : "off",
+    //"no-console": process.env.NODE_ENV === "production" ? "error" : "off",
+    "no-console": "off",
     "no-debugger": process.env.NODE_ENV === "production" ? "error" : "off"
   },
   parserOptions: {

--- a/dtool-lookup-webapp/README.md
+++ b/dtool-lookup-webapp/README.md
@@ -1,9 +1,18 @@
 # dtool-lookup-webapp
 
-## Project setup
+## Project setup (for development)
 ```
 npm install
 ```
+
+### Configure endpoints
+
+Create a file `.env` in the `dtool-lookup-webapp` directory with the following contents:
+```
+VUE_APP_LOOKUP_URL="http://localhost:5000"
+VUE_APP_TOKEN_GENERATOR_URL="http://localhost:5001/token"
+```
+For deployment, replace these URLs with the actual endpoints of the lookup server and the token generator.
 
 ### Compiles and hot-reloads for development
 ```
@@ -25,5 +34,18 @@ npm run test
 npm run lint
 ```
 
-### Customize configuration
+## Project setup (for deployment)
+
+Install packages and configure endpoints as described above.
+
+### Compile
+```
+npm run build
+```
+
+### Run web server
+
+Configure webserver (e.g. [nginx](https://nginx.org/)) to statically serve the `dist` subdirectory create by the _build_ command.
+
+## Customize configuration
 See [Configuration Reference](https://cli.vuejs.org/config/).

--- a/dtool-lookup-webapp/README.md
+++ b/dtool-lookup-webapp/README.md
@@ -9,8 +9,8 @@ npm install
 
 Create a file `.env` in the `dtool-lookup-webapp` directory with the following contents:
 ```
-VUE_APP_LOOKUP_URL="http://localhost:5000"
-VUE_APP_TOKEN_GENERATOR_URL="http://localhost:5001/token"
+VUE_APP_DTOOL_LOOKUP_SERVER_URL="http://localhost:5000"
+VUE_APP_DTOOL_LOOKUP_SERVER_TOKEN_GENERATOR_URL="http://localhost:5001/token"
 ```
 For deployment, replace these URLs with the actual endpoints of the lookup server and the token generator.
 

--- a/dtool-lookup-webapp/src/App.vue
+++ b/dtool-lookup-webapp/src/App.vue
@@ -178,7 +178,7 @@ export default {
       readmeErrored: false,
       annotationsLoading: false,
       annotationsErrored: false,
-      lookup_url: process.env.LOOKUP_URL,
+      lookup_url: process.env.VUE_APP_LOOKUP_URL,
       token: null
     };
   },

--- a/dtool-lookup-webapp/src/App.vue
+++ b/dtool-lookup-webapp/src/App.vue
@@ -178,7 +178,7 @@ export default {
       readmeErrored: false,
       annotationsLoading: false,
       annotationsErrored: false,
-      lookup_url: process.env.VUE_APP_LOOKUP_URL,
+      lookup_url: process.env.VUE_APP_DTOOL_LOOKUP_SERVER_URL,
       token: null
     };
   },

--- a/dtool-lookup-webapp/src/App.vue
+++ b/dtool-lookup-webapp/src/App.vue
@@ -178,7 +178,7 @@ export default {
       readmeErrored: false,
       annotationsLoading: false,
       annotationsErrored: false,
-      lookup_url: "https://dtool-lookup-server.informatics.jic.ac.uk",
+      lookup_url: process.env.LOOKUP_URL,
       token: null
     };
   },

--- a/dtool-lookup-webapp/src/components/SignIn.vue
+++ b/dtool-lookup-webapp/src/components/SignIn.vue
@@ -55,7 +55,7 @@ export default {
       signInInfo: null,
       signInLoading: false,
       signInErrored: false,
-      tokenGeneratorURL: "https://token-generator.informatics.jic.ac.uk/token"
+      tokenGeneratorURL: process.env.TOKEN_GENERATOR_URL
     };
   },
   computed: {

--- a/dtool-lookup-webapp/src/components/SignIn.vue
+++ b/dtool-lookup-webapp/src/components/SignIn.vue
@@ -55,7 +55,7 @@ export default {
       signInInfo: null,
       signInLoading: false,
       signInErrored: false,
-      tokenGeneratorURL: process.env.TOKEN_GENERATOR_URL
+      tokenGeneratorURL: process.env.VUE_APP_TOKEN_GENERATOR_URL
     };
   },
   computed: {

--- a/dtool-lookup-webapp/src/components/SignIn.vue
+++ b/dtool-lookup-webapp/src/components/SignIn.vue
@@ -55,7 +55,7 @@ export default {
       signInInfo: null,
       signInLoading: false,
       signInErrored: false,
-      tokenGeneratorURL: process.env.VUE_APP_TOKEN_GENERATOR_URL
+      tokenGeneratorURL: process.env.VUE_APP_DTOOL_LOOKUP_SERVER_TOKEN_GENERATOR_URL
     };
   },
   computed: {
@@ -68,6 +68,7 @@ export default {
       this.$emit("sign-in", token);
     },
     getToken: function() {
+      console.log(process.env);
       this.signInLoading = true;
       this.$http
         .post(this.tokenGeneratorURL, this.loginCredentials, {


### PR DESCRIPTION
The URLs for the lookup server and the token generator can now be configured by providing a file `.env` in the webapp directory, e.g.:
```
VUE_APP_LOOKUP_URL="http://localhost:5000"
VUE_APP_TOKEN_GENERATOR_URL="http://localhost:5001/token"
```
Also, the check for console output was disabled for eslint since this interfered with `npm run build`.
