### PR TITLE
Make the OAuth2 login URL configurable (VUE_APP_OAUTH2_LOGIN_URL)

### DIFF
--- a/dtool-lookup-webapp/src/components/SignIn.vue
+++ b/dtool-lookup-webapp/src/components/SignIn.vue
@@ -208,7 +208,7 @@ import { ref, computed } from "vue";
 import axios from "axios";
 import type { AxiosError, AxiosResponse } from "axios";
 import type { ResourceLink } from "@/types";
-import { serverUrl, tokenGeneratorUrl } from "@/config";
+import { tokenGeneratorUrl, oauth2LoginUrl } from "@/config";
 import { useNotificationStore } from "@/stores/notifications";
 import { useAuthStore } from "@/stores/auth";
 
@@ -232,7 +232,7 @@ const logoSrc =
 // OAuth2 configuration
 const oauth2Enabled = process.env.VUE_APP_OAUTH2_ENABLED === "true";
 const oauth2ProviderName = process.env.VUE_APP_OAUTH2_PROVIDER_NAME || "OAuth2";
-const oauth2LoginUrl = `${serverUrl}/auth/login`;
+// oauth2LoginUrl is imported from @/config (env-configurable via VUE_APP_OAUTH2_LOGIN_URL)
 // Show username/password form if OAuth2 is disabled or if explicitly enabled
 const showUsernamePasswordForm =
   !oauth2Enabled || process.env.VUE_APP_SHOW_USERNAME_PASSWORD_FORM === "true";

--- a/dtool-lookup-webapp/src/config.ts
+++ b/dtool-lookup-webapp/src/config.ts
@@ -17,4 +17,7 @@ export const authLogoutUrl: string =
   process.env.VUE_APP_DTOOL_LOOKUP_SERVER_AUTH_LOGOUT_URL ||
   `${serverUrl}/auth/logout`;
 
+export const oauth2LoginUrl: string =
+  process.env.VUE_APP_OAUTH2_LOGIN_URL || `${serverUrl}/auth/login`;
+
 export const authEnabled = process.env.VUE_APP_AUTH_ENABLED !== "false";


### PR DESCRIPTION
`SignIn.vue` hardcoded the OAuth2 login URL as `${serverUrl}/auth/login`. This exposes it from `config.ts` as `oauth2LoginUrl`, defaulting to the same value but overridable via `VUE_APP_OAUTH2_LOGIN_URL` — mirroring the existing `tokenGeneratorUrl` / `authLogoutUrl` pattern.

This lets a deployment serve the OAuth2 endpoints under a non-default prefix (e.g. `/auth/oauth2`) and point the login button at it without editing source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)