### PR TITLE
Send JWT when downloading config templates

### DIFF
--- a/dtool-lookup-webapp/src/components/UserMenu.vue
+++ b/dtool-lookup-webapp/src/components/UserMenu.vue
@@ -341,8 +341,15 @@ async function downloadFile(fileName: string): Promise<void> {
       : process.env.VUE_APP_DTOOL_README_YAML_PATH ||
         `data/templates/${fileName}`;
 
+  // Send the JWT so server-side generators (e.g. the config-generator plugin)
+  // can produce a per-user file. Harmless for static template paths.
+  const headers: Record<string, string> = {};
+  if (authEnabled && auth.token) {
+    headers["Authorization"] = `Bearer ${auth.token}`;
+  }
+
   try {
-    const response = await fetch(filePath);
+    const response = await fetch(filePath, { headers });
     if (!response.ok) throw new Error("Network response was not ok");
 
     const text = await response.text();


### PR DESCRIPTION
`downloadFile()` did a bare unauthenticated `fetch`, which only works for static files. This attaches `Authorization: Bearer <token>` (from the auth store, when auth is enabled) so a **server-side generator** can return a **per-user** `dtool.json` / readme. Harmless for static template paths.

Pairs with a dserver `config-generator` plugin that serves `/config-generator/dtool.json` and `/config-generator/dtool_readme.yml`.

> Stacked on #36 (base `2026-06-18-ldap-auth`); retarget to the default branch once #36 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)